### PR TITLE
Fix accessToken

### DIFF
--- a/packages/MVTImageryProvider/src/MVTImageryProvider.ts
+++ b/packages/MVTImageryProvider/src/MVTImageryProvider.ts
@@ -129,10 +129,7 @@ class MVTImageryProvider {
     let promise: any = data
     if (typeof data === 'string') {
       data = new Resource({
-        url: data,
-        queryParameters: {
-          access_token: this._accessToken
-        }
+        url: data
       })
     }
     if (data instanceof Resource) {


### PR DESCRIPTION
refs to: [Method _preLoad add access_token two times to queryParameters](https://github.com/hongfaqiu/MVTImageryProvider/issues/19)